### PR TITLE
Change dependency tidalapi4mopidy back to tidalapi

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -7,7 +7,7 @@ import sys
 from mopidy import config, ext
 
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 
 # TODO: If you need to log, use loggers named after the current Python module
 logger = logging.getLogger(__name__)

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -6,7 +6,7 @@ from mopidy import backend
 
 from pykka import ThreadingActor
 
-from tidalapi4mopidy import Config, Session
+from tidalapi import Config, Session, Quality
 
 from mopidy_tidal import library, playback, playlists
 
@@ -30,7 +30,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
     def on_start(self):
         quality = self._config['tidal']['quality']
         logger.info("Connecting to TIDAL.. Quality = %s" % quality)
-        config = Config(quality=quality)
+        config = Config(quality=Quality(quality))
         self._session = Session(config)
         if self._session.login(self._username, self._password):
             logger.info("TIDAL Login OK")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0',
         'Pykka >= 1.1',
-        'tidalapi4mopidy >= 0.1.2',
+        'tidalapi >= 0.6.4,<0.7.0',
         'requests >= 2.0.0',
     ],
     entry_points={


### PR DESCRIPTION
It looks like the tidalapi library was forked to resolve an issue a while ago;
https://github.com/tehkillerbee/python-tidal/commit/ebde51062167c4be81cab3709c65bed2cffbb26e

This repository has now been archived, and it looks like this issue (and others) has since been resolved in the original repository;
https://github.com/tamland/python-tidal/commit/da206eec9f078f9a34ca04cbdce4b9a854a6fcd4 
