### PR TITLE
Use new OAuth flow added in upstream tidalapi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,15 @@ For High and Low quality be sure to have installed gstreamer bad-plugins, for eg
 
 This is mandatory to be able to play m4a streams.
 
+OAuth Flow
+----------
+
+Using the new OAuth flow, you now have to visit a link to connect the app to your login. When you restart the Mopidy server, check the logs and find a line like:
+
+    ``Visit link.tidal.com/AAAAA to log in, the code will expire in 300 seconds``
+
+Go to that link in your browser, approve it, and that should be it. Note that this is a **blocking** action, so Mopidy will not load until you approve the application. You will also have to do this every time Mopidy restarts.
+
 Project resources
 =================
 

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -32,7 +32,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
         logger.info("Connecting to TIDAL.. Quality = %s" % quality)
         config = Config(quality=Quality(quality))
         self._session = Session(config)
-        if self._session.login(self._username, self._password):
+        if self._session.login_oauth_simple(function=logger.info):
             logger.info("TIDAL Login OK")
         else:
             logger.info("TIDAL Login KO")

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 3.0',
         'Pykka >= 1.1',
-        'tidalapi >= 0.6.7,<0.7.0',
+        'tidalapi >= 0.6.8,<0.7.0',
         'requests >= 2.0.0',
     ],
     entry_points={


### PR DESCRIPTION
Since the standard login seems to have broken, the upstream [python-tidal](https://github.com/tamland/python-tidal/compare/v0.6.7...v0.6.8) library changed over to using an OAuth flow. This PR updates mopidy-tidal to use the new flow. Note the changes in the README.

Curious what people think of this approach. Maybe as an alternative, it would be better to have a separate application that dumps out the OAuth tokens, and then you have to add them as part of the mopidy-tidal config?