### PR TITLE
Remove unused login information config options

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -27,8 +27,6 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
-        schema['username'] = config.String()
-        schema['password'] = config.Secret()
         schema['quality'] = config.String(choices=["LOSSLESS", "HIGH", "LOW"])
         return schema
 

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -22,8 +22,6 @@ class TidalBackend(ThreadingActor, backend.Backend):
         super(TidalBackend, self).__init__()
         self._session = None
         self._config = config
-        self._username = config['tidal']['username']
-        self._password = config['tidal']['password']
         self.playback = playback.TidalPlaybackProvider(audio=audio,
                                                        backend=self)
         self.library = library.TidalLibraryProvider(backend=self)

--- a/mopidy_tidal/ext.conf
+++ b/mopidy_tidal/ext.conf
@@ -1,5 +1,3 @@
 [tidal]
 enabled = true
-username=
-password=
 quality=LOSSLESS


### PR DESCRIPTION
Due to the new OAuth process password and username went unused during
login and the configuration of these is never accessed in the code.