### PR TITLE
added client_id & client_secret to [tidal] in mopidy config

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -28,8 +28,8 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['quality'] = config.String(choices=["LOSSLESS", "HIGH", "LOW"])
-        schema['client_id'] = config.String()
-        schema['client_secret'] = config.String()
+        schema['client_id'] = config.String(optional=True)
+        schema['client_secret'] = config.String(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -28,6 +28,8 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['quality'] = config.String(choices=["LOSSLESS", "HIGH", "LOW"])
+        schema['client_id'] = config.String()
+        schema['client_secret'] = config.String()
         return schema
 
     def setup(self, registry):

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -47,15 +47,20 @@ class TidalBackend(ThreadingActor, backend.Backend):
         config = Config(quality=Quality(quality))
         client_id = self._config['tidal']['client_id']
         client_secret = self._config['tidal']['client_secret']
-        if client_id and client_id.strip():
-            logger.info("Connecting to TIDAL.. Client ID read from config .. Client ID = %s" % client_id)
+
+        if (client_id and not client_secret) or (client_secret and not client_id):
+            logger.warn("Connecting to TIDAL.. always provide client_id and client_secret together")
+            logger.info("Connecting to TIDAL.. client id & client secret from pyhtontidal are used")
+        
+        if client_id and client_secret:
+            logger.info("Connecting to TIDAL.. client id & client secret from config section are used")
             config.client_id=client_id
             config.api_token=client_id
-            if client_secret and client_secret.strip():
-                logger.info("Connecting to TIDAL.. Client Secret read from config .. Client Secret = %s" % client_secret)
-                config.client_secret=client_secret
-            else:
-                logger.warn("Connecting to TIDAL.. client_id without client_secret will fail")
+            config.client_secret=client_secret
+
+        if not client_id and not client_secret:
+            logger.info("Connecting to TIDAL.. client id & client secret from pyhtontidal are used")
+
         self._session = Session(config)
         oauth_file = os.path.join(os.getenv("HOME"), '.config/', 'tidal-oauth.json')
         try:

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -45,6 +45,17 @@ class TidalBackend(ThreadingActor, backend.Backend):
         quality = self._config['tidal']['quality']
         logger.info("Connecting to TIDAL.. Quality = %s" % quality)
         config = Config(quality=Quality(quality))
+        client_id = self._config['tidal']['client_id']
+        client_secret = self._config['tidal']['client_secret']
+        if client_id and client_id.strip():
+            logger.info("Connecting to TIDAL.. Client ID read from config .. Client ID = %s" % client_id)
+            config.client_id=client_id
+            config.api_token=client_id
+            if client_secret and client_secret.strip():
+                logger.info("Connecting to TIDAL.. Client Secret read from config .. Client Secret = %s" % client_secret)
+                config.client_secret=client_secret
+            else:
+                logger.warn("Connecting to TIDAL.. client_id without client_secret will fail")
         self._session = Session(config)
         oauth_file = os.path.join(os.getenv("HOME"), '.config/', 'tidal-oauth.json')
         try:

--- a/mopidy_tidal/ext.conf
+++ b/mopidy_tidal/ext.conf
@@ -1,3 +1,5 @@
 [tidal]
 enabled = true
 quality=LOSSLESS
+client_id=
+client_secret=


### PR DESCRIPTION
client_id & client_secret will be used instead of default
from tidalapi if defined in mopidy config

as requested pull request