### PR TITLE
Changed tidal-oauth output directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,17 +32,23 @@ Configuration
 =============
 
 Before starting Mopidy, you must add configuration for
-Mopidy-Tidal to your Mopidy configuration file::
+Mopidy-Tidal to your Mopidy configuration file, if it is not already present.
+
+The configuration is usually stored in `/etc/mopidy/mopidy.conf` or possibly `~/.config/mopidy/mopidy.conf`, depending on your system configuration ::
 
     [tidal]
     enabled = true
     quality = LOSSLESS
+    #client_id =
+    #client_secret =
 
 
 Quality can be set to LOSSLESS, HIGH or LOW. Hi_RES(master) is currently not supported.
 Lossless quality (FLAC) requires Tidal HiFi Subscription.
 
-For High and Low quality be sure to have installed gstreamer bad-plugins, eg. ::
+Tidal API `client_id`, `client_secret` can be overridden by the user if necessary.
+
+When using High and Low quality, be sure to install gstreamer bad-plugins, eg. ::
 
     sudo apt-get install gstreamer1.0-plugins-bad
 
@@ -81,8 +87,9 @@ Changelog
 
 v0.2.6
 ----------------------------------------
+- Improved reliability of OAuth cache file generation.
+- Added optional client_id & client_secret to [tidal] in mopidy config (Glog78)
 - Removed username/pass, as it is not needed by OAuth (thanks tbjep)
-- 
 
 v0.2.5
 ----------------------------------------

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -50,7 +50,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
 
         if (client_id and not client_secret) or (client_secret and not client_id):
             logger.warn("Connecting to TIDAL.. always provide client_id and client_secret together")
-            logger.info("Connecting to TIDAL.. client id & client secret from pyhtontidal are used")
+            logger.info("Connecting to TIDAL.. using default client id & client secret from python-tidal")
         
         if client_id and client_secret:
             logger.info("Connecting to TIDAL.. client id & client secret from config section are used")
@@ -59,10 +59,12 @@ class TidalBackend(ThreadingActor, backend.Backend):
             config.client_secret=client_secret
 
         if not client_id and not client_secret:
-            logger.info("Connecting to TIDAL.. client id & client secret from pyhtontidal are used")
+            logger.info("Connecting to TIDAL.. using default client id & client secret from python-tidal")
 
         self._session = Session(config)
-        oauth_file = os.path.join(os.getenv("HOME"), '.config/', 'tidal-oauth.json')
+        # Always store tidal-oauth cache in mopidy core config data_dir
+        data_dir = self._config['core']['data_dir']
+        oauth_file = os.path.join(data_dir, 'tidal-oauth.json')
         try:
             # attempt to reload existing session from file
             with open(oauth_file) as f:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 3.0',
         'Pykka >= 1.1',
-        'tidalapi >= 0.6.8,<0.7.0',
+        'tidalapi >= 0.6.9,<0.7.0',
         'requests >= 2.0.0',
     ],
     entry_points={


### PR DESCRIPTION
Determine the correct mopidy data_dir from the configuration file, instead of using HOME env. variable. This should make sure that the user has the correct permissions to write the tidal-oauth json file.

Updated setup.py to use latest tidalapi, as this version updates the API key.