### PR TITLE
Updated tidalapi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 3.0',
         'Pykka >= 1.1',
-        'tidalapi @ git+https://github.com/tamland/python-tidal.git@0.7.x',
+        'tidalapi >= 0.7.0',
         'requests >= 2.0.0',
     ],
     entry_points={


### PR DESCRIPTION
Now that `python-tidal` has officially merged the 0.7.x branch into master and released a new version on pypi, we can safely use the `tidalapi >= 0.7.0` dependency instead of relying on the branch.