### PR TITLE
Temporary fix for the missing user picture error on tidalapi

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -16,7 +16,6 @@ sys.path.append(file_dir)
 
 
 class Extension(ext.Extension):
-
     dist_name = "Mopidy-Tidal"
     ext_name = "tidal"
     version = __version__

--- a/mopidy_tidal/playlists.py
+++ b/mopidy_tidal/playlists.py
@@ -108,7 +108,6 @@ class TidalPlaylistsProvider(backend.PlaylistsProvider):
         return added_ids, removed_ids
 
     def _has_changes(self, playlist: MopidyPlaylist):
-
         upstream_playlist = self.backend._session.playlist(playlist.uri.split(":")[-1])
         if not upstream_playlist:
             return True

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "setuptools",
         "Mopidy >= 3.0",
         "Pykka >= 1.1",
-        "tidalapi >= 0.7.0",
+        "tidalapi @ git+https://github.com/BlackLight/python-tidal",
         "requests >= 2.0.0",
     ],
     entry_points={


### PR DESCRIPTION
tidalapi recently started breaking after logging in because of the missing `picture` field on the user JSON response (see https://github.com/tamland/python-tidal/issues/129).

I have [pushed a PR](https://github.com/tamland/python-tidal/pull/130) to quickly fix the issue, but it may take a while to get merged (the project has a quite long queue of pending PRs).

In the meantime, as a workaround, this PR makes the project depend on my fork (which includes the fix) instead of the latest published release.