### PR TITLE
Feat/lazy connection

### DIFF
--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -30,6 +30,7 @@ class Extension(ext.Extension):
         schema["client_id"] = config.String(optional=True)
         schema["client_secret"] = config.String(optional=True)
         schema["playlist_cache_refresh_secs"] = config.Integer(optional=True)
+        schema["lazy"] = config.Boolean(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -13,6 +13,10 @@ from mopidy_tidal import Extension, context, library, playback, playlists
 logger = logging.getLogger(__name__)
 
 
+def _connecting_log(msg: str, level="info"):
+    getattr(logger, level)("Connecting to TIDAL... " + msg)
+
+
 class TidalBackend(ThreadingActor, backend.Backend):
     def __init__(self, config, audio):
         super(TidalBackend, self).__init__()
@@ -39,31 +43,25 @@ class TidalBackend(ThreadingActor, backend.Backend):
 
     def on_start(self):
         quality = self._config["tidal"]["quality"]
-        logger.info("Connecting to TIDAL.. Quality = %s" % quality)
+        _connecting_log("Quality = %s" % quality)
         config = Config(quality=Quality(quality))
         client_id = self._config["tidal"]["client_id"]
         client_secret = self._config["tidal"]["client_secret"]
 
         if (client_id and not client_secret) or (client_secret and not client_id):
-            logger.warning(
-                "Connecting to TIDAL.. always provide client_id and client_secret together"
+            _connecting_log(
+                "always provide client_id and client_secret together", "warning"
             )
-            logger.info(
-                "Connecting to TIDAL.. using default client id & client secret from python-tidal"
-            )
+            _connecting_log("using default client id & client secret from python-tidal")
 
         if client_id and client_secret:
-            logger.info(
-                "Connecting to TIDAL.. client id & client secret from config section are used"
-            )
+            _connecting_log("client id & client secret from config section are used")
             config.client_id = client_id
             config.api_token = client_id
             config.client_secret = client_secret
 
         if not client_id and not client_secret:
-            logger.info(
-                "Connecting to TIDAL.. using default client id & client secret from python-tidal"
-            )
+            _connecting_log("using default client id & client secret from python-tidal")
 
         self._session = Session(config)
         # Always store tidal-oauth cache in mopidy core config data_dir

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -32,10 +32,6 @@ class TidalBackend(ThreadingActor, backend.Backend):
     def _session(self):
         return self._active_session
 
-    @_session.setter
-    def _session(self, session):
-        self._active_session = session
-
     def oauth_login_new_session(self, oauth_file):
         # create a new session
         self._active_session.login_oauth_simple(function=logger.info)

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -35,7 +35,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
             self._login()
         return self._active_session
 
-    def oauth_login_new_session(self, oauth_file):
+    def _oauth_login_new_session(self, oauth_file):
         # create a new session
         self._active_session.login_oauth_simple(function=logger.info)
         if self._active_session.check_login():
@@ -89,7 +89,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
 
         if not self._active_session.check_login():
             logger.info("Creating new OAuth session...")
-            self.oauth_login_new_session(oauth_file)
+            self._oauth_login_new_session(oauth_file)
 
         if self._active_session.check_login():
             logger.info("TIDAL Login OK")

--- a/mopidy_tidal/ext.conf
+++ b/mopidy_tidal/ext.conf
@@ -4,3 +4,4 @@ quality=LOSSLESS
 client_id=
 client_secret=
 playlist_cache_refresh_secs = 0
+lazy=false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def config(tmp_path):
             "client_id": "client_id",
             "client_secret": "client_secret",
             "quality": "LOSSLESS",
+            "lazy": False,
         },
     }
     context.set_config(cfg)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -36,7 +36,7 @@ def test_composition(get_backend):
 def test_setup(get_backend):
     backend, config, *_ = get_backend()
     assert tuple(backend.uri_schemes) == ("tidal",)  # TODO: why is this muteable?
-    assert not backend._session
+    assert not backend._active_session
     assert backend._config is config
 
 
@@ -48,7 +48,7 @@ def test_login(get_backend, tmp_path, mocker):
     session.session_id = "session_id"
     session.access_token = "access_token"
     session.refresh_token = "refresh_token"
-    backend._session = session
+    backend._active_session = session
     authf = tmp_path / "auth.json"
     assert not authf.exists()
     backend.oauth_login_new_session(authf)
@@ -67,7 +67,7 @@ def test_login(get_backend, tmp_path, mocker):
 def test_failed_login(get_backend, tmp_path, mocker):
     backend, _, _, _, session = get_backend()
     session.check_login.return_value = False
-    backend._session = session
+    backend._active_session = session
     authf = tmp_path / "auth.json"
     backend.oauth_login_new_session(authf)
     assert not authf.exists()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,4 @@
-from json import dump, load
+from json import dump, dumps, load, loads
 from pathlib import Path
 
 import pytest
@@ -16,6 +16,10 @@ def get_backend(mocker):
         backend = TidalBackend(config, audio)
         session_factory = mocker.Mock()
         session = mocker.Mock()
+        session.token_type = "token_type"
+        session.session_id = "session_id"
+        session.access_token = "access_token"
+        session.refresh_token = "refresh_token"
         session_factory.return_value = session
         mocker.patch("mopidy_tidal.backend.Session", session_factory)
         return backend, config, audio, session_factory, session
@@ -41,17 +45,18 @@ def test_setup(get_backend):
 
 
 @pytest.mark.gt_3_7
-def test_login(get_backend, tmp_path, mocker):
-    backend, _, _, _, session = get_backend()
-    session.check_login.return_value = True
-    session.token_type = "token_type"
-    session.session_id = "session_id"
-    session.access_token = "access_token"
-    session.refresh_token = "refresh_token"
+def test_initial_login_caches_credentials(get_backend, config):
+    backend, _, _, _, session = get_backend(config=config)
+    session.check_login.return_value = False
+
+    def login(*_, **__):
+        session.check_login.return_value = True
+
+    session.login_oauth_simple.side_effect = login
     backend._active_session = session
-    authf = tmp_path / "auth.json"
+    authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     assert not authf.exists()
-    backend.oauth_login_new_session(authf)
+    backend._login()
     with authf.open() as f:
         data = load(f)
     assert data == {
@@ -64,13 +69,60 @@ def test_login(get_backend, tmp_path, mocker):
 
 
 @pytest.mark.gt_3_7
-def test_failed_login_falls_back_to_new_oauth(get_backend, tmp_path, mocker):
-    backend, _, _, _, session = get_backend()
+def test_login_after_failed_cached_credentials_overwrites_cached_credentials(
+    get_backend, config
+):
+    backend, _, _, _, session = get_backend(config=config)
     session.check_login.return_value = False
+
+    def login(*_, **__):
+        session.check_login.return_value = True
+
+    session.login_oauth_simple.side_effect = login
     backend._active_session = session
-    authf = tmp_path / "auth.json"
-    backend.oauth_login_new_session(authf)
-    assert not authf.exists()
+    authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
+    cached_data = {
+        "token_type": dict(data="token_type2"),
+        "session_id": dict(data="session_id2"),
+        "access_token": dict(data="access_token2"),
+        "refresh_token": dict(data="refresh_token2"),
+    }
+    authf.write_text(dumps(cached_data))
+
+    backend._login()
+    with authf.open() as f:
+        data = load(f)
+    assert data == {
+        "token_type": dict(data="token_type"),
+        "session_id": dict(data="session_id"),
+        "access_token": dict(data="access_token"),
+        "refresh_token": dict(data="refresh_token"),
+    }
+    session.login_oauth_simple.assert_called_once()
+
+
+@pytest.mark.gt_3_7
+def test_failed_login_does_not_overwrite_cached_credentials(
+    get_backend, mocker, config, tmp_path
+):
+    backend, _, _, _, session = get_backend(config=config)
+    session.check_login.return_value = False
+
+    backend._active_session = session
+    authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
+    cached_data = {
+        "token_type": dict(data="token_type2"),
+        "session_id": dict(data="session_id2"),
+        "access_token": dict(data="access_token2"),
+        "refresh_token": dict(data="refresh_token2"),
+    }
+    authf.write_text(dumps(cached_data))
+
+    with pytest.raises(ConnectionError):
+        backend._login()
+
+    data = loads(authf.read_text())
+    assert data == cached_data
     session.login_oauth_simple.assert_called_once()
 
 
@@ -88,15 +140,14 @@ def test_failed_overall_login_throws_error(get_backend, tmp_path, mocker, config
 @pytest.mark.gt_3_7
 def test_logs_in(get_backend, mocker, config):
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend.oauth_login_new_session = mocker.Mock()
+    backend._active_session = session
 
-    def set_logged_in(*_):
+    def set_logged_in(*_, **__):
         session.check_login.return_value = True
 
-    backend.oauth_login_new_session.side_effect = set_logged_in
+    session.login_oauth_simple.side_effect = set_logged_in
     session.check_login.return_value = False
     backend.on_start()
-    backend.oauth_login_new_session.assert_called_once()
     session_factory.assert_called_once()
     config_obj = session_factory.mock_calls[0].args[0]
     assert config_obj.quality == config["tidal"]["quality"]
@@ -108,19 +159,17 @@ def test_logs_in(get_backend, mocker, config):
 def test_accessing_session_triggers_lazy_login(get_backend, mocker, config):
     config["tidal"]["lazy"] = True
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend.oauth_login_new_session = mocker.Mock()
 
-    def set_logged_in(*_):
+    def set_logged_in(*_, **__):
         session.check_login.return_value = True
 
-    backend.oauth_login_new_session.side_effect = set_logged_in
     session.check_login.return_value = False
+    session.login_oauth_simple.side_effect = set_logged_in
     backend.on_start()
-    backend.oauth_login_new_session.assert_not_called()
+    session.login_oauth_simple.assert_not_called()
     assert not backend._active_session.check_login()
     assert backend._session
     assert backend._session.check_login()
-    backend.oauth_login_new_session.assert_called_once()
     session_factory.assert_called_once()
     config_obj = session_factory.mock_calls[0].args[0]
     assert config_obj.quality == config["tidal"]["quality"]
@@ -132,15 +181,14 @@ def test_accessing_session_triggers_lazy_login(get_backend, mocker, config):
 def test_logs_in_only_client_secret(get_backend, mocker, config):
     config["tidal"]["client_id"] = ""
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend.oauth_login_new_session = mocker.Mock()
 
-    def set_logged_in(*_):
+    def set_logged_in(*_, **__):
         session.check_login.return_value = True
 
-    backend.oauth_login_new_session.side_effect = set_logged_in
+    session.login_oauth_simple.side_effect = set_logged_in
     session.check_login.return_value = False
     backend.on_start()
-    backend.oauth_login_new_session.assert_called_once()
+    session.login_oauth_simple.assert_called_once()
     session_factory.assert_called_once()
     config_obj = session_factory.mock_calls[0].args[0]
     assert config_obj.quality == config["tidal"]["quality"]
@@ -152,19 +200,18 @@ def test_logs_in_only_client_secret(get_backend, mocker, config):
 
 
 @pytest.mark.gt_3_7
-def test_logs_in_default(get_backend, mocker, config):
+def test_logs_in_default_id_secret(get_backend, mocker, config):
     config["tidal"]["client_id"] = ""
     config["tidal"]["client_secret"] = ""
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend.oauth_login_new_session = mocker.Mock()
 
-    def set_logged_in(*_):
+    def set_logged_in(*_, **__):
         session.check_login.return_value = True
 
-    backend.oauth_login_new_session.side_effect = set_logged_in
+    session.login_oauth_simple.side_effect = set_logged_in
     session.check_login.return_value = False
     backend.on_start()
-    backend.oauth_login_new_session.assert_called_once()
+    session.login_oauth_simple.assert_called_once()
     session_factory.assert_called_once()
     config_obj = session_factory.mock_calls[0].args[0]
     assert config_obj.quality == config["tidal"]["quality"]
@@ -177,7 +224,6 @@ def test_logs_in_default(get_backend, mocker, config):
 
 def test_loads_session(get_backend, mocker, config):
     backend, config, _, session_factory, session = get_backend(config=config)
-    backend.oauth_login_new_session = mocker.Mock()
 
     authf = Path(config["core"]["data_dir"], "tidal") / "tidal-oauth.json"
     data = {
@@ -191,6 +237,6 @@ def test_loads_session(get_backend, mocker, config):
     session.check_login.return_value = True
     backend.on_start()
     args = {k: v["data"] for k, v in data.items() if k != "session_id"}
-    backend.oauth_login_new_session.assert_not_called()
+    session.login_oauth_simple.assert_not_called()
     session.load_oauth_session.assert_called_once_with(**args)
     session_factory.assert_called_once()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -23,7 +23,7 @@ def test_get_config_schema():
     # Test the content of your config schema
     assert "quality" in schema
     assert "client_id" in schema
-    assert "client_secret"
+    assert "client_secret" in schema
 
 
 @pytest.mark.gt_3_7

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -24,6 +24,7 @@ def test_get_config_schema():
     assert "quality" in schema
     assert "client_id" in schema
     assert "client_secret" in schema
+    assert "lazy" in schema
 
 
 @pytest.mark.gt_3_7


### PR DESCRIPTION
This PR finally reimplements lazy connection logic on top of the new tidal api.

I've also added a few more tests to justify the assertions in the readme, and cleaned up the test suite a bit.

The only public member of backend is now `on_start`.  I think `_session` should become public (`session`) as it's actually used from outside, but I've not made the change (I'll add it if you agree).