### PR TITLE
ci: use personal codecov token to avoid rate limit.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,6 @@ jobs:
         if: ${{ matrix.python-version  == '3.10' }}
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
       - run: echo ${{ matrix.python-version }}


### PR DESCRIPTION
This should fix the intermittent ci failures.

It does require action your side: you need to create a new secret called `CODECOV_TOKEN` with the token in it.  The token can be copied from the codecov repo page (it's not an api token, apparently, having tried that), i.e. hopefully here:
https://app.codecov.io/gh/tehkillerbee/mopidy-tidal/settings

And then you can make a new repository secret here: https://github.com/tehkillerbee/mopidy-tidal/settings/secrets/actions/new

Assuming that is I got those urls right.  But it's not like you needed them anyhow, I just still had the tabs open.

See https://github.com/codecov/codecov-action/issues/557.