### PR TITLE
Feature/add-support-for-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### v0.3.4
+- Added support for navigating For You, Explore pages.
+
 #### v0.3.3
 - Added HI_RES_LOSSLESS quality (Requires HiFi+ subscription)
 

--- a/mopidy_tidal/library.py
+++ b/mopidy_tidal/library.py
@@ -81,7 +81,7 @@ class ImagesGetter:
         elif item_type == "mix":
             item_id = parts[2]
         else:
-            # uri has no ID associated to it (eg. tidal:mood, tidal:mixes, tidal:genres etc.)
+            # uri has no image associated to it (eg. tidal:mood tidal:genres etc.)
             return []
 
         if uri in self._image_cache:
@@ -202,6 +202,18 @@ class TidalLibraryProvider(backend.LibraryProvider):
             return ref_models_mappers.create_tracks(
                 get_items(session.user.favorites.tracks)
             )
+        elif uri == "tidal:home":
+            return ref_models_mappers.create_mixed_directory(
+                [m for m in session.home()]
+            )
+        elif uri == "tidal:for_you":
+            return ref_models_mappers.create_mixed_directory(
+                [m for m in session.for_you()]
+            )
+        elif uri == "tidal:explore":
+            return ref_models_mappers.create_mixed_directory(
+                [m for m in session.explore()]
+            )
         elif uri == "tidal:moods":
             return ref_models_mappers.create_moods(session.moods())
         elif uri == "tidal:mixes":
@@ -210,7 +222,6 @@ class TidalLibraryProvider(backend.LibraryProvider):
             return ref_models_mappers.create_genres(session.genre.get_genres())
 
         # details
-
         parts = uri.split(":")
         nr_of_parts = len(parts)
 
@@ -249,6 +260,9 @@ class TidalLibraryProvider(backend.LibraryProvider):
             return ref_models_mappers.create_tracks(
                 self._get_mix_tracks(session, parts[2])
             )
+
+        if nr_of_parts == 3 and parts[1] == "page":
+            return ref_models_mappers.create_mixed_directory(session.page.get(parts[2]))
 
         logger.debug("Unknown uri for browse request: %s", uri)
         return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mopidy-tidal"
-version = "0.3.3"
+version = "0.3.4"
 description = "Mopidy Extension for Tidal music service integration."
 authors = ["Johannes Linde <tehkillerbee@users.noreply.github.com>"]
 license = "Apache License 2.0"


### PR DESCRIPTION
This PR adds support for navigating pages (for_you, explore). This allows browsing and playback of tidal suggestions (mixes, playlists, albums etc.)

Known bugs: 
- Some playlists do not have an image associated to it. (Why?)