### PR TITLE
Use full_name instead of name to better identify tracks in mopidy

### DIFF
--- a/mopidy_tidal/full_models_mappers.py
+++ b/mopidy_tidal/full_models_mappers.py
@@ -63,7 +63,7 @@ def create_mopidy_track(artist, album, tidal_track):
     track_len = tidal_track.duration * 1000
     return Track(
         uri=uri,
-        name=tidal_track.name,
+        name=tidal_track.full_name,
         track_no=tidal_track.track_num,
         artists=[artist],
         album=album,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def make_track(track_id, artist, album):
     track = Mock(spec=Track, name=f"Track: {track_counter()}")
     track.id = track_id
     track.name = f"Track-{track_id}"
+    track.full_name = f"{track.name} (version)"
     track.artist = artist
     track.album = album
     track.uri = f"tidal:track:{artist.id}:{album.id}:{track_id}"
@@ -135,7 +136,7 @@ def tidal_playlists(mocker, tidal_tracks):
 
 def compare_track(tidal, mopidy):
     assert tidal.uri == mopidy.uri
-    assert tidal.name == mopidy.name
+    assert tidal.full_name == mopidy.name
     assert tidal.duration * 1000 == mopidy.length
     assert tidal.disc_num == mopidy.disc_no
     assert tidal.track_num == mopidy.track_no

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -234,6 +234,7 @@ def api_test(tpp, mocker, api_method, tp):
         track.id = i
         track.uri = f"tidal:track:{i}:{i}:{i}"
         track.name = f"Track-{i}"
+        track.full_name = f"{track.name} (version)"
         track.artist.name = "artist_name"
         track.artist.id = i
         track.album.name = "album_name"
@@ -253,11 +254,11 @@ def api_test(tpp, mocker, api_method, tp):
     assert playlist.name == "Playlist-1"
     assert playlist.uri == "tidal:playlist:1-1-1"
     assert len(playlist.tracks) == 2 * len(api_method.mock_calls)
-    attr_map = {"disc_num": "disc_no"}
+    attr_map = {"disc_num": "disc_no", "full_name": "name"}
     assert all(
         getattr(orig_tr, k) == getattr(tr, attr_map.get(k, k))
         for orig_tr, tr in zip(tracks, playlist.tracks)
-        for k in {"name", "uri", "disc_num"}
+        for k in {"uri", "disc_num", "full_name"}
     )
 
 
@@ -440,6 +441,7 @@ def test_get_items_mix(tpp, mocker):
         track.id = i
         track.uri = f"tidal:track:{i}:{i}:{i}"
         track.name = f"Track-{i}"
+        track.full_name = f"{track.name} (version)"
         track.artist.name = "artist_name"
         track.artist.id = i
         track.album.name = "album_name"
@@ -454,6 +456,6 @@ def test_get_items_mix(tpp, mocker):
     playlist = mocker.MagicMock(last_modified=9, tracks=tracks)
     tpp._playlists["tidal:mix:0-1-2"] = playlist
     assert tpp.get_items("tidal:mix:0-1-2") == [
-        Ref(name="Track-0", type="track", uri="tidal:track:0:0:0"),
-        Ref(name="Track-1", type="track", uri="tidal:track:1:1:1"),
+        Ref(name="Track-0 (version)", type="track", uri="tidal:track:0:0:0"),
+        Ref(name="Track-1 (version)", type="track", uri="tidal:track:1:1:1"),
     ]


### PR DESCRIPTION
Won't expand much further than the title, using the `tidal_track.name` as the `mopidy_track.name` results on a very confusing experience, especially on Single EPs with an original track and multiple remixes of it, being presented all with the same name.

I checked the python-tidal repo and now we can get a `full_name` containing the track `version` field on it: https://github.com/tamland/python-tidal/blob/1d2ae41967368a2ce2d0880b0d28adf5b2dbe553/tidalapi/media.py#L177

Took advantage of that and updated here a simple spot and the tests affected.