### PR TITLE
Explicitly set token type when using pkce auth.

### DIFF
--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -190,7 +190,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
                     str, Union[str, int]
                 ] = self._active_session.pkce_get_auth_token(url_redirect)
                 # Parse and set tokens.
-                self._active_session.process_auth_token(json)
+                self._active_session.process_auth_token(json, is_pkce_token=True)
                 self._logged_in = True
             except:
                 raise ValueError("Response code is required for PKCE login!")


### PR DESCRIPTION
Fixes https://github.com/tehkillerbee/mopidy-tidal/issues/168

Related PR: https://github.com/tamland/python-tidal/pull/247