### PR TITLE
Support Mopidy v4.0 tracks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-Mopidy = "^3.0"
+Mopidy = ">=3.0,<5.0"
 tidalapi = "^0.8.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The `library.lookup` method should now support both the cases where the tracks returned by Mopidy are Tracks/TlTracks (Mopidy < 4.0) and where they are dict-like representations (Mopidy >= 4.0).